### PR TITLE
update to use (non-final) pydantic generated schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,7 @@ Visual Studio Code extension for [Runway](https://github.com/onicagroup/runway) 
 ## Features
 
 - `runway.yml`/`runway.yaml` validation and autocompletion
-  - `deployments` definition
-  - `tests` definition
-  - `variables` definition
 - description on hover for key and values
-  - some include links to documentation
 
 ## Usage
 
@@ -28,11 +24,6 @@ This extension modifies the [User Settings](https://code.visualstudio.com/docs/g
 ## Requirements
 
 - [redhat.vscode-yaml](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) extension
-
-## Known Issues
-
-- advanced `modules` definition does not have validation or hover text
-- schema error when supplying `regions` and `parallel_regions` is unclear
 
 ## Release Notes
 

--- a/schemas/runway.schema.json
+++ b/schemas/runway.schema.json
@@ -1,371 +1,715 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/ITProKyle/vscode-runway/blob/master/schema/runway.schema.json",
-  "title": "Runway Config File",
-  "description": "Schema for a Runway Config file (runway.yaml | runway.yml)",
-  "type": "object",
-  "properties": {
-    "deployments": {
-      "description": "A list of Runway deployment definitions.\nhttps://docs.onica.com/projects/runway/en/release/runway_config.html#deployment",
-      "type": "array",
-      "items": {
-        "description": "Defines a deployment that will be processed by Runway.\nhttps://docs.onica.com/projects/runway/en/release/runway_config.html#deployment",
-        "type": "object",
-        "properties": {
-          "account_alias": {
-            "description": "Mapping of {<environment>: <alias>}.\nUsed to verify the currently assumed role or credentials.",
-            "oneOf": [
-              {
-                "description": "Lookup that must resolve to a mapping of {<environment>: <alias>}.\nUsed to verify the currently assumed role or credentials.",
-                "type": "string"
-              },
-              {
-                "description": "Mapping of {<environment>: <alias>}.\nUsed to verify the currently assumed role or credentials.",
-                "type": "object",
-                "patternProperties": {
-                  "^.*$": {
-                    "description": "AWS account alias belonging to an environment.",
-                    "type": "string"
-                  }
-                }
-              }
-            ]
-          },
-          "account_id": {
-            "description": "Mapping of {<environment>: <id>}.\nUsed to verify the currently assumed role or credentials.",
-            "oneOf": [
-              {
-                "description": "Lookup that must resolve to a mapping of {<environment>: <id>}.\nUsed to verify the currently assumed role or credentials.",
-                "type": "string"
-              },
-              {
-                "description": "Mapping of {<environment>: <id>}.\nUsed to verify the currently assumed role or credentials.",
-                "type": "object",
-                "patternProperties": {
-                  "^.*$": {
-                    "description": "AWS account alias belonging to an environment.",
-                    "type": "string"
-                  }
-                }
-              }
-            ]
-          },
-          "assume_role": {
-            "description": "Mapping of {<environment>: <role>} or {<environment>: {arn: <role>, duration: <int>}} to assume a role when processing a deployment.\n  - {arn: <role>} can be used to apply the same role to all environment.\n  - {post_deploy_env_revert: true} can also be provided to revert credentials after processing.",
-            "type": "object",
-            "oneOf": [
-              {
-                "properties": {
-                  "arn": {
-                    "description": "AWS IAM Role ARN that will be assumed.",
-                    "type": "string"
-                  },
-                  "post_deploy_env_revert": {
-                    "description": "Revert credentials after processing.",
-                    "type": "boolean"
-                  }
-                },
-                "additionalProperties": false
-              },
-              {
-                "properties": {
-                  "post_deploy_env_revert": {
-                    "description": "Revert credentials after processing.",
-                    "type": "boolean"
-                  }
-                },
-                "patternProperties": {
-                  "^(?!^arn$).*": {
-                    "description": "AWS IAM Role ARN that will be assumed for an environment.",
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "arn": {
-                            "description": "AWS IAM Role ARN that will be assumed.",
-                            "type": "string"
-                          },
-                          "duration": {
-                            "description": "Number of seconds the assumed role's credentials will be valid for.",
-                            "type": "integer",
-                            "default": 3600,
-                            "minimum": 0,
-                            "maximum": 43200
-                          },
-                          "additionalProperties": false
-                        },
-                        "required": [
-                          "arn"
-                        ]
-                      }
-                    ]
-                  }
-                },
-                "additionalProperties": false
-              }
-            ]
-          },
-          "environments": {
-            "description": "Mapping of environment names to a boolean value used to explicitly enable or disable in an environment. This can be used when an environment specific variables file and parameters are not needed to force a module to enable anyway or, explicitly skip a module even if a file or parameters are found.\nThe mapping can also have a string (or list of strings) value of '<ACCOUNT_ID>/<REGION>' to lock an environment to specific regions in a specific accounts. If it matches, it will act as an explicit enable.",
-            "type": "object",
-            "patternProperties": {
-              "^.*$": {
-                  "anyOf": [
-                      {
-                          "description": "Lock the environment to a list of specific '<ACCOUNT_ID>/<REGION>'s.",
-                          "type": "array",
-                          "items": {
-                              "description": "Lock the environment to a specific '<ACCOUNT_ID>/<REGION>'.",
-                              "type": "string"
-                          }
-                      },
-                      {
-                          "description": "Explicitly enable or disable for the environment.",
-                          "type": "boolean"
-                      },
-                      {
-                          "description": "Lock the environment to a specific '<ACCOUNT_ID>/<REGION>'.",
-                          "type": "string"
-                      }
-                  ]
-              }
-          }
-          },
-          "env_vars": {
-            "description": "Mapping of OS environment variable overrides to apply when processing modules in the deployment.\nCan be defined per environment or for all environments by omitting the environment name.",
-            "type": "object",
-            "patternProperties": {
-              "^.*$": {
-                "anyOf": [
-                  {
-                    "description": "Environment variable value.",
-                    "type": "string"
-                  },
-                  {
-                    "description": "Environment variables.",
-                    "type": "object",
-                    "patternProperties": {
-                      "^.*$": {
-                        "description": "Environment variable value.",
-                        "type": "string"
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          "modules": {
-            "description": "A list of modules to be processed in the order they are defined.",
+    "title": "Runway Configuration File",
+    "description": "Configuration file for use with Runway.",
+    "type": "object",
+    "properties": {
+        "deployments": {
+            "title": "Deployments",
+            "description": "Array of Runway deployments definitions.",
+            "default": [],
             "type": "array",
             "items": {
-              "anyOf": [
-                {
-                  "description": "Simple module definition.",
-                  "type": "string"
-                },
-                {
-                  "description": "Advanced module definition.\n  # TODO define schema",
-                  "type": "object"
-                }
-              ]
+                "$ref": "#/definitions/RunwayDeploymentDefinitionModel"
             }
-          },
-          "module_options": {
-            "description": "Options that are shared among all modules in the deployment.\nhttps://docs.onica.com/projects/runway/en/release/module_configuration/index.html",
-            "type": "object",
-            "patternProperties": {
-              "^.*$": {
-                "oneOf": [
-                  {
-                    "description": "https://docs.onica.com/projects/runway/en/latest/module_configuration/index.html",
-                    "type": "string"
-                  },
-                  {
-                    "description": "https://docs.onica.com/projects/runway/en/latest/module_configuration/index.html",
-                    "type": "object",
-                    "patternProperties": {
-                      "^.*$": {
-                          "type": "string"
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          "name": {
-            "description": "Name of the deployment. Used to more easily identify where different deployments begin/end in the logs.",
-            "type": "string"
-          },
-          "regions": {
-            "description": "AWS region names where modules will be processed.\nCan also be define as a mapping with 'parallel' as the key and a list of regions as the value.\nCannot be provided if 'parallel_regions' is provided.",
-            "oneOf": [
-              {
-                "type": "array",
-                "items": {
-                  "description": "AWS region code.",
-                  "type": "string"
-                },
-                "minItems": 1,
-                "uniqueItems": true
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "parallel": {
-                    "description": "List of AWS regions to run in parallel.",
-                    "type": "array",
-                    "items": {
-                      "description": "AWS region code.",
-                      "type": "string"
-                    },
-                    "minItems": 1,
-                    "uniqueItems": true
-                  }
-                },
-                "additionalProperties": false
-              }
-            ]
-          },
-          "parallel_regions": {
-            "description": "List of AWS regions to run in parallel.",
-            "type": "array",
-            "items": {
-              "description": "AWS region code.",
-              "type": "string"
+        },
+        "future": {
+            "title": "Future",
+            "default": {
+                "strict_environments": false
             },
-            "minItems": 1,
-            "uniqueItems": true
-          },
-          "parameters": {
-            "description": "Module level parameters that are akin to a CloudFormation parameter in functionality.\nThese can be used to pass variable values to your modules in place of a .env/.tfenv/environment config file.\nThrough the use of Lookups, the value can differ per deploy environment, region, etc.",
-            "type": "object",
-            "patternProperties": {
-              "^.*$": {
-                "description": "Parameter passed to the modules at runtime."
-              }
-            }
-          }
+            "allOf": [
+                {
+                    "$ref": "#/definitions/RunwayFutureDefinitionModel"
+                }
+            ]
         },
-        "additionalProperties": false,
-        "oneOf": [
-          {
-            "required": [
-              "modules",
-              "regions"
+        "ignore_git_branch": {
+            "title": "Ignore Git Branch",
+            "description": "Optionally exclude the git branch name when determining the current deploy environment.",
+            "default": false,
+            "type": "boolean"
+        },
+        "runway_version": {
+            "title": "Runway Version",
+            "description": "Define the versions of Runway that can be used with this configuration file.",
+            "default": ">1.10",
+            "examples": [
+                "\"<2.0.0\"",
+                "\"==1.14.0\"",
+                "\">=1.14.0,<2.0.0\""
             ],
-            "not": {
-              "required": [
-                "parallel_regions"
-              ]
+            "type": "string"
+        },
+        "tests": {
+            "title": "Tests",
+            "description": "Array of Runway test definitions that are executed with the 'test' command.",
+            "default": [],
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/RunwayTestDefinitionModel"
             }
-          },
-          {
-            "required": [
-              "modules",
-              "parallel_regions"
-            ],
-            "not": {
-              "required": [
-                "regions"
-              ]
-            }
-          }
-        ]
-      }
+        },
+        "variables": {
+            "title": "Variables",
+            "default": {
+                "file_path": null,
+                "sys_path": "/Users/kyle/repos/runway"
+            },
+            "allOf": [
+                {
+                    "$ref": "#/definitions/RunwayVariablesDefinitionModel"
+                }
+            ]
+        }
     },
-    "tests": {
-      "description": "A list of tests Runway will execute with `runway test`.\nhttps://docs.onica.com/projects/runway/en/release/defining_tests.html",
-      "type": "array",
-      "items": {
-        "description": "Runway test definition.",
-        "type": "object",
-        "properties": {
-          "args": {
-            "description": "A mapping of arguments that are specific to each test type.\nhttps://docs.onica.com/projects/runway/en/release/defining_tests.html",
+    "additionalProperties": false,
+    "definitions": {
+        "RunwayAssumeRoleDefinitionModel": {
+            "title": "Runway Deployment.assume_role Definition",
+            "description": "Used to defined a role to assume while Runway is processing each module.",
             "type": "object",
-            "anyOf": [
-              {
-                "properties": {
-                  "commands": {
-                    "description": "Used with 'script' to provide a list of commands to be run. Each command is executed in their own subprocess.",
+            "properties": {
+                "arn": {
+                    "title": "IAM Role ARN",
+                    "description": "The ARN of the AWS IAM role to be assumed. (supports lookups)",
+                    "type": "string"
+                },
+                "duration": {
+                    "title": "Duration",
+                    "description": "The duration, in seconds, of the role session. (supports lookups)",
+                    "default": 3600,
+                    "anyOf": [
+                        {
+                            "type": "integer",
+                            "minimum": 900,
+                            "maximum": 43200
+                        },
+                        {
+                            "type": "string",
+                            "pattern": "^\\${.*}$"
+                        }
+                    ]
+                },
+                "post_deploy_env_revert": {
+                    "title": "Post Deployment Environment Revert",
+                    "description": "Revert the credentials stored in environment variables to what they were prior to execution after the deployment finished processing. (supports lookups)",
+                    "default": false,
+                    "type": "boolean"
+                },
+                "session_name": {
+                    "title": "Session Name",
+                    "description": "An identifier for the assumed role session. (supports lookups)",
+                    "default": "runway",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "arn": "arn:aws:iam::123456789012:role/name"
+                },
+                {
+                    "arn": "${var role_arn.${env DEPLOY_ENVIRONMENT}}",
+                    "duration": 9001,
+                    "post_deploy_env_revert": true,
+                    "session_name": "runway-example"
+                }
+            ]
+        },
+        "ValidRunwayModuleTypeValues": {
+            "title": "Runway Module Type",
+            "description": "Explicitly define the type of IaC contained within the directory.",
+            "enum": [
+                "cdk",
+                "cloudformation",
+                "serverless",
+                "terraform",
+                "kubernetes",
+                "static"
+            ]
+        },
+        "RunwayModuleDefinitionModel": {
+            "title": "Runway Module Definition",
+            "description": "Defines a directory containing IaC, the parameters to pass in during execution, and any applicable options for the module type.",
+            "type": "object",
+            "properties": {
+                "class_path": {
+                    "title": "Class Path",
+                    "description": "Import path to a custom Runway module class. (supports lookups)",
+                    "type": "string"
+                },
+                "env_vars": {
+                    "title": "Environment Variables",
+                    "description": "Additional variables to add to the environment when processing the deployment. (supports lookups)",
+                    "default": {},
+                    "examples": [
+                        "${var env_vars.${env DEPLOY_ENVIRONMENT}}",
+                        {
+                            "EXAMPLE_VARIABLE": "value",
+                            "KUBECONFIG": [
+                                ".kube",
+                                "${env DEPLOY_ENVIRONMENT}",
+                                "config"
+                            ]
+                        }
+                    ],
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "additionalProperties": {
+                                "anyOf": [
+                                    {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    {
+                                        "type": "string"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "environments": {
+                    "title": "Environments",
+                    "description": "Explicitly enable/disable the deployment for a specific deploy environment, AWS Account ID, and AWS Region combination. Can also be set as a static boolean value. (supports lookups)",
+                    "default": {},
+                    "examples": [
+                        "${var envs.${env DEPLOY_ENVIRONMENT}}",
+                        {
+                            "dev": "123456789012",
+                            "prod": "us-east-1"
+                        },
+                        {
+                            "dev": true,
+                            "prod": false
+                        },
+                        {
+                            "dev": [
+                                "us-east-1"
+                            ],
+                            "prod": [
+                                "us-west-2",
+                                "ca-central-1"
+                            ]
+                        },
+                        {
+                            "dev": [
+                                "123456789012/us-east-1",
+                                "123456789012/us-west-2"
+                            ],
+                            "prod": [
+                                "234567890123/us-east-1",
+                                "234567890123/us-west-2"
+                            ]
+                        }
+                    ],
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "additionalProperties": {
+                                "anyOf": [
+                                    {
+                                        "type": "boolean"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    {
+                                        "type": "string"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "name": {
+                    "title": "Name",
+                    "description": "The name of the module to be displayed in logs and the interactive selection menu.",
+                    "default": "undefined",
+                    "type": "string"
+                },
+                "options": {
+                    "title": "Options",
+                    "description": "Module type specific options. (supports lookups)",
+                    "default": {},
+                    "anyOf": [
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "parameters": {
+                    "title": "Parameters",
+                    "description": "Used to pass variable values to modules in place of an environment configuration file. (supports lookups)",
+                    "default": {},
+                    "examples": [
+                        {
+                            "namespace": "example-${env DEPLOY_ENVIRONMENT}"
+                        },
+                        "${var sampleapp.parameters.${env DEPLOY_ENVIRONMENT}}"
+                    ],
+                    "anyOf": [
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "path": {
+                    "title": "Path",
+                    "description": "Directory (relative to the Runway config file) containing IaC. (supports lookups)",
+                    "examples": [
+                        "./",
+                        "sampleapp-${env DEPLOY_ENVIRONMENT}.cfn",
+                        "sampleapp.sls"
+                    ],
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "string",
+                            "format": "path"
+                        }
+                    ]
+                },
+                "tags": {
+                    "title": "Tags",
+                    "description": "Array of values to categorize the module which can be used with the CLI to quickly select a group of modules. This field is only used by the `--tag` CLI option.",
+                    "default": [],
+                    "examples": [
+                        [
+                            "type:network",
+                            "app:sampleapp"
+                        ]
+                    ],
                     "type": "array",
                     "items": {
-                      "description": "Command to be executed.",
-                      "type": "string"
+                        "type": "string"
                     }
-                  }
+                },
+                "type": {
+                    "$ref": "#/definitions/ValidRunwayModuleTypeValues"
+                },
+                "parallel": {
+                    "title": "Parallel",
+                    "description": "Array of module definitions that can be executed asynchronously. Incompatible with class_path, path, and type.",
+                    "default": [],
+                    "examples": [
+                        [
+                            {
+                                "path": "sampleapp-01.cfn"
+                            },
+                            {
+                                "path": "sampleapp-02.cfn"
+                            }
+                        ]
+                    ],
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/RunwayModuleDefinitionModel"
+                    }
                 }
-              },
-              {
-                "patternProperties": {
-                  "^.*$": {
-                    "description": "Argument specific to the test's type.\nhttps://docs.onica.com/projects/runway/en/stable/defining_tests.html"
-                  }
+            },
+            "additionalProperties": false
+        },
+        "RunwayDeploymentDefinitionModel": {
+            "title": "Runway Deployment Definition",
+            "description": "A collection of modules, regions, and other configurations to deploy.",
+            "type": "object",
+            "properties": {
+                "account_alias": {
+                    "title": "Account Alias",
+                    "description": "Used to verify the currently assumed role or credentials. (supports lookups)",
+                    "default": {},
+                    "examples": [
+                        {
+                            "dev": "example-dev",
+                            "prod": "example-prod"
+                        },
+                        "example-alias",
+                        "${var alias.${env DEPLOY_ENVIRONMENT}}"
+                    ],
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "account_id": {
+                    "title": "Account Id",
+                    "description": "Used to verify the currently assumed role or credentials. (supports lookups)",
+                    "default": {},
+                    "examples": [
+                        {
+                            "dev": "123456789012",
+                            "prod": "234567890123"
+                        },
+                        "123456789012",
+                        "${var id.${env DEPLOY_ENVIRONMENT}}"
+                    ],
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "assume_role": {
+                    "title": "Assume Role",
+                    "description": "Assume a role when processing the deployment. (supports lookups)",
+                    "default": {},
+                    "examples": [
+                        "arn:aws:iam::123456789012:role/name",
+                        {
+                            "arn": "arn:aws:iam::123456789012:role/name"
+                        },
+                        {
+                            "arn": "${var role_arn.${env DEPLOY_ENVIRONMENT}}",
+                            "duration": 9001,
+                            "post_deploy_env_revert": true,
+                            "session_name": "runway-example"
+                        }
+                    ],
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "$ref": "#/definitions/RunwayAssumeRoleDefinitionModel"
+                        }
+                    ]
+                },
+                "env_vars": {
+                    "title": "Environment Variables",
+                    "description": "Additional variables to add to the environment when processing the deployment. (supports lookups)",
+                    "default": {},
+                    "examples": [
+                        "${var env_vars.${env DEPLOY_ENVIRONMENT}}",
+                        {
+                            "EXAMPLE_VARIABLE": "value",
+                            "KUBECONFIG": [
+                                ".kube",
+                                "${env DEPLOY_ENVIRONMENT}",
+                                "config"
+                            ]
+                        }
+                    ],
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "additionalProperties": {
+                                "anyOf": [
+                                    {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    {
+                                        "type": "string"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "environments": {
+                    "title": "Environments",
+                    "description": "Explicitly enable/disable the deployment for a specific deploy environment, AWS Account ID, and AWS Region combination. Can also be set as a static boolean value. (supports lookups)",
+                    "default": {},
+                    "examples": [
+                        "${var envs.${env DEPLOY_ENVIRONMENT}}",
+                        {
+                            "dev": "123456789012",
+                            "prod": "us-east-1"
+                        },
+                        {
+                            "dev": true,
+                            "prod": false
+                        },
+                        {
+                            "dev": [
+                                "us-east-1"
+                            ],
+                            "prod": [
+                                "us-west-2",
+                                "ca-central-1"
+                            ]
+                        },
+                        {
+                            "dev": [
+                                "123456789012/us-east-1",
+                                "123456789012/us-west-2"
+                            ],
+                            "prod": [
+                                "234567890123/us-east-1",
+                                "234567890123/us-west-2"
+                            ]
+                        }
+                    ],
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "additionalProperties": {
+                                "anyOf": [
+                                    {
+                                        "type": "boolean"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    {
+                                        "type": "string"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "modules": {
+                    "title": "Modules",
+                    "description": "An array of modules to process as part of a deployment.",
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/RunwayModuleDefinitionModel"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ]
+                    }
+                },
+                "module_options": {
+                    "title": "Module Options",
+                    "description": "Options that are passed directly to the modules within this deployment. (supports lookups)",
+                    "default": {},
+                    "examples": [
+                        "${var sampleapp.options.${env DEPLOY_ENVIRONMENT}}",
+                        {
+                            "some_option": "value"
+                        }
+                    ],
+                    "anyOf": [
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "name": {
+                    "title": "Name",
+                    "description": "The name of the deployment to be displayed in logs and the interactive selection menu.",
+                    "default": "unnamed_deployment",
+                    "type": "string"
+                },
+                "parallel_regions": {
+                    "title": "Parallel Regions",
+                    "description": "An array of AWS Regions to process asynchronously. (supports lookups)",
+                    "default": [],
+                    "examples": [
+                        [
+                            "us-east-1",
+                            "us-west-2"
+                        ],
+                        "${var regions.${dev DEPLOY_ENVIRONMENT}}"
+                    ],
+                    "anyOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "parameters": {
+                    "title": "Parameters",
+                    "description": "Used to pass variable values to modules in place of an environment configuration file. (supports lookups)",
+                    "default": {},
+                    "examples": [
+                        {
+                            "namespace": "example-${env DEPLOY_ENVIRONMENT}"
+                        },
+                        "${var sampleapp.parameters.${env DEPLOY_ENVIRONMENT}}"
+                    ],
+                    "anyOf": [
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "regions": {
+                    "title": "Regions",
+                    "description": "An array of AWS Regions to process this deployment in. (supports lookups)",
+                    "default": [],
+                    "examples": [
+                        [
+                            "us-east-1",
+                            "us-west-2"
+                        ],
+                        "${var regions.${dev DEPLOY_ENVIRONMENT}}",
+                        {
+                            "parallel": [
+                                "us-east-1",
+                                "us-east-2"
+                            ]
+                        },
+                        {
+                            "parallel": "${var regions.${env DEPLOY_ENVIRONMENT}}"
+                        }
+                    ],
+                    "anyOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
                 }
-              }
-            ]
-          },
-          "name": {
-            "description": "A short name to describe the test.",
-            "type": "string"
-          },
-          "required": {
-            "description": "If `false`, test failure will return 0 instead of resulting in an error.",
-            "oneOf": [
-              {
-                "type":"boolean"
-              },
-              {
-                "description": "Lookup that must resolve to a boolean value.",
-                "type": "string"
-              }
+            },
+            "required": [
+                "modules"
             ],
-            "default": true
-          },
-          "type": {
-            "description": "The built-in test type to use.",
-            "type": "string",
-            "default": "script",
+            "additionalProperties": false
+        },
+        "RunwayFutureDefinitionModel": {
+            "title": "Runway Future Definition",
+            "description": "Enable features/behaviors that will be become standard ahead of their official release.",
+            "type": "object",
+            "properties": {
+                "strict_environments": {
+                    "title": "Strict Environments",
+                    "description": "If 'environments' is included in a deployment, modules will be skipped if the current environment is not defined.",
+                    "default": false,
+                    "type": "boolean"
+                }
+            },
+            "additionalProperties": false
+        },
+        "ValidRunwayTestTypeValues": {
+            "title": "Runway Test Type",
+            "description": "The type of test to run.",
             "enum": [
-              "cfn-lint",
-              "script",
-              "yamllint"
+                "cfn-lint",
+                "script",
+                "yamllint"
             ]
-          }
         },
-        "required": [
-          "type"
-        ]
-      }
-    },
-    "variables": {
-      "description": "Explicitly define the path to a YAML file containing variables.\nCan also be used to override values in the file or provide additional variables.",
-      "type": "object",
-      "properties": {
-        "file_path": {
-          "description": "Explicit path to a variables file.\nIf it cannot be found Runway will exit.",
-          "type": "string",
-          "default": "runway.variables.yml"
+        "RunwayTestDefinitionModel": {
+            "title": "Runway Test Definition",
+            "description": "Tests that can be run via the 'test' command.",
+            "type": "object",
+            "properties": {
+                "args": {
+                    "title": "Arguments",
+                    "description": "Arguments to be passed to the test. Support varies by test type.",
+                    "default": {},
+                    "anyOf": [
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "name": {
+                    "title": "Name",
+                    "description": "Name of the test.",
+                    "type": "string"
+                },
+                "required": {
+                    "title": "Required",
+                    "description": "Whether the test must pass for subsequent tests to be run.",
+                    "default": true,
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "type": {
+                    "$ref": "#/definitions/ValidRunwayTestTypeValues"
+                }
+            },
+            "required": [
+                "type"
+            ]
         },
-        "sys_path": {
-          "description": "Directory to use as the base of a relative 'file_path'.\nIf not provided, the location of the Runway config file is used.",
-          "type": "string",
-          "default": "./"
+        "RunwayVariablesDefinitionModel": {
+            "title": "Runway Variables Definition",
+            "description": "A variable definitions for the Runway config file. This is used to resolve the 'var' lookup.",
+            "type": "object",
+            "properties": {
+                "file_path": {
+                    "title": "Variables File Path",
+                    "description": "Explicit path to a variables file that will be loaded and merged with the variables defined here.",
+                    "type": "string",
+                    "format": "path"
+                },
+                "sys_path": {
+                    "title": "Sys Path",
+                    "description": "Directory to use as the root of a relative 'file_path'. If not provided, the current working directory is used.",
+                    "default": "/Users/kyle/repos/runway",
+                    "type": "string",
+                    "format": "path"
+                }
+            }
         }
-      },
-      "patternProperties": {
-        "^.*$": {
-            "description": "Additional or override variable."
-        }
-      }
     }
-  },
-  "required": [
-    "deployments"
-  ]
 }

--- a/schemas/runway.schema.json
+++ b/schemas/runway.schema.json
@@ -117,7 +117,7 @@
             ]
         },
         "ValidRunwayModuleTypeValues": {
-            "title": "Runway Module Type",
+            "title": "Module Type",
             "description": "Explicitly define the type of IaC contained within the directory.",
             "enum": [
                 "cdk",
@@ -639,7 +639,7 @@
             "additionalProperties": false
         },
         "ValidRunwayTestTypeValues": {
-            "title": "Runway Test Type",
+            "title": "Test Type",
             "description": "The type of test to run.",
             "enum": [
                 "cfn-lint",


### PR DESCRIPTION

## Summary

Replace the hand written JSON schema with one that is generated from type annotations of the Runway config class. This is using a version of the config that is still in development but should be nearly feature complete. This will be updated again once https://github.com/onicagroup/runway/pull/455 is merged.

## What Changed

### Changed

- updated the runway schema using pydantic export
